### PR TITLE
Add support for symlinks between archive and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ This doc briefly goes over the steps involved in building the plugin for testing
 - Install Docker
 - Run the following commands:
   - az login
-  - az acr login --name jgalaasocr
-    - This is to allow us to pull images from a private registry called `jgalaasocr`.
-  - docker pull jgalaasocr.azurecr.io/copytoolbuildimage/gobuild
+  - az acr login --name [container-registry-name]
+    - This is to allow us to pull images from a private registry called `[container-registry-name]`.
+  - docker pull [container-registry-name].azurecr.io/copytoolbuildimage/gobuild
 
 ### To build the executable
 
-- docker run --name gobuild -v /{path-to-your-lemur-project-code}:/usr/src/lemur -it jgalaasocr.azurecr.io/copytoolbuildimage/gobuild:latest
+- docker run --name gobuild -v /{path-to-your-lemur-project-code}:/usr/src/lemur -it [container-registry-name].azurecr.io/copytoolbuildimage/gobuild:latest
   - Explanation:
     - We are starting a container that has all the right dependencies built (especially Lustre itself)
     - The -v flag is mapping a path on your machine (the lemur project) into a specific path on the container, so that the source code shows up inside the container.

--- a/cmd/lhsm-plugin-az-core/archive.go
+++ b/cmd/lhsm-plugin-az-core/archive.go
@@ -6,6 +6,8 @@ import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"net/url"
 	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 )
 
@@ -23,12 +25,48 @@ type ArchiveOptions struct {
 func Archive(o ArchiveOptions) (int64, error){
 	ctx := context.TODO()
 	p := azblob.NewPipeline(o.Credential, azblob.PipelineOptions{})
+
+	// We might actually encounter symlinks here.
+	paths := []string{o.SourcePath}
+
+	for {
+		idx := len(paths)-1
+
+		// In the original code, the error was ignored, so we're going to maintain the assumption that it's OK to ignore the error here
+		// Though it's not really the most agreeable thing.
+		fi, _ := os.Lstat(paths[idx])
+
+		// If the file is not a symlink, we can jump to uploading it.
+		if fi.Mode() & os.ModeSymlink == 0 {
+			break
+		}
+
+		// Otherwise, read the link and append it.
+		next, err := os.Readlink(paths[idx])
+
+		if err != nil {
+			return 0, err
+		}
+
+		paths = append(paths, next)
+	}
+
+	// Currently, we know the absolute paths, with 0 being the first link in the chain and n being the file itself.
+	// Let's decipher what the actual root is, so we know where our blobs live.
+	// Each of our blob names are going to be strings.TrimPrefix(path, fsRootPath)
+	fsRootPath := strings.TrimSuffix(filepath.Dir(o.SourcePath), filepath.Dir(o.BlobName)) + "/"
+
+	// First, upload the file... We know exactly where this is and what it's going to be named, thus, we'll fix paths[n] so that links go right.
+
+	//// First, upload the file. TODO: Detect if the file and links already exist
+	//// To do this, we need to know the relative paths...
+
 	cURL, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s", o.AccountName, o.ContainerName))
 	containerURL := azblob.NewContainerURL(*cURL, p)
-	blobURL := containerURL.NewBlockBlobURL(o.BlobName)
+	blobURL := containerURL.NewBlockBlobURL(strings.TrimSuffix(strings.TrimPrefix(paths[len(paths)-1], fsRootPath), "/"))
 
 	// open the file to read from
-	file, _ := os.Open(o.SourcePath)
+	file, _ := os.Open(paths[len(paths)-1])
 	fileInfo, _ := file.Stat()
 	defer file.Close()
 
@@ -49,6 +87,33 @@ func Archive(o ArchiveOptions) (int64, error){
 			Parallelism: o.Parallelism,
 			Metadata:    meta,
 		})
+
+	if err != nil {
+		return 0, err
+	}
+
+	//// Prior to creating the links, we need to change what the first link is to match the new destination.
+	//// @Narasimha, this should help you with supporting the custom names.
+	//paths[len(paths)-1] = path.Join(fsRootPath, o.BlobName)
+
+	// Then, create the links. We do it backwards, much like we do for a download.
+	for idx := len(paths) - 2; idx >= 0; idx-- {
+		linkName := strings.TrimPrefix(paths[idx], fsRootPath)
+		linkDest := strings.TrimPrefix(paths[idx+1], fsRootPath)
+
+		_, err = azblob.UploadBufferToBlockBlob(
+			ctx,
+			[]byte(linkDest),
+			containerURL.NewBlockBlobURL(linkName),
+			azblob.UploadToBlockBlobOptions{
+				Metadata: azblob.Metadata{ "ftype":"LNK" },
+			},
+		)
+
+		if err != nil {
+			return 0, err
+		}
+	}
 
 	return total, err
 }

--- a/cmd/lhsm-plugin-az-core/restore.go
+++ b/cmd/lhsm-plugin-az-core/restore.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	"github.com/pkg/errors"
+	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 )
 
 type RestoreOptions struct {
@@ -23,17 +25,56 @@ type RestoreOptions struct {
 func Restore(o RestoreOptions) (int64, error){
 	ctx := context.TODO()
 	p := azblob.NewPipeline(o.Credential, azblob.PipelineOptions{})
-	u, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", o.AccountName, o.ContainerName, o.BlobName))
 
-	// fetch the properties first so that we know how big the source blob is
-	blobURL := azblob.NewBlobURL(*u, p)
-	blobProp, err := blobURL.GetProperties(ctx, azblob.BlobAccessConditions{})
-	if err != nil {
-		return 0, errors.Wrapf(err, "GetProperties on %s failed", o.BlobName)
+	// First, try to weed out until the symlink.
+	// Symlinks are actually somewhat of an edge-case here that isn't expected,
+	// But we decided that being defensive on the off chance it happens wasn't a bad idea.
+	paths := []string{o.BlobName}
+	contentLen, err := int64(0), error(nil)
+
+	for {
+		u, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", o.AccountName, o.ContainerName, paths[len(paths) - 1]))
+
+		blobURL := azblob.NewBlobURL(*u, p)
+		blobProp, err := blobURL.GetProperties(ctx, azblob.BlobAccessConditions{})
+		if err != nil {
+			return 0, errors.Wrapf(err, "GetProperties on %s failed", o.BlobName)
+		}
+		// When we exit this loop, we've either failed to get a link, or we've reached a real file.
+		contentLen = blobProp.ContentLength()
+		metadata := blobProp.NewMetadata()
+
+		// TODO: Get properties, break when we hit a non-link
+		if metadata["ftype"] != "LNK" {
+			break
+		}
+
+		// If we got a link, read it and move forward.
+		resp, err := blobURL.Download(ctx, 0, 0, azblob.BlobAccessConditions{}, false)
+
+		if err != nil {
+			return contentLen, err
+		}
+
+		buf, err := ioutil.ReadAll(resp.Body(azblob.RetryReaderOptions{
+			MaxRetryRequests:       3,
+			TreatEarlyCloseAsError: false,
+		}))
+
+		if err != nil {
+			return contentLen, err
+		}
+
+		paths = append(paths, string(buf))
 	}
-	contentLen := blobProp.ContentLength()
 
-	file, _ := os.Create(o.DestinationPath)
+	u, _ := url.Parse(fmt.Sprintf("https://%s.blob.core.windows.net/%s/%s", o.AccountName, o.ContainerName, paths[len(paths) - 1]))
+
+	blobURL := azblob.NewBlobURL(*u, p)
+
+	basePath := path.Dir(o.DestinationPath)
+
+	file, _ := os.Create(path.Join(basePath, paths[len(paths)-1]))
 	defer file.Close()
 	err = azblob.DownloadBlobToFile(
 		ctx, blobURL, 0, 0, file,
@@ -41,6 +82,23 @@ func Restore(o RestoreOptions) (int64, error){
 			BlockSize:  o.BlockSize,
 			Parallelism: o.Parallelism,
 		})
+
+	//paths = paths[:len(paths)-1]
+
+	for i := len(paths) - 2; i >= 0; i-- {
+		err = os.MkdirAll(path.Join(basePath, path.Dir(paths[i])), os.ModeDir | os.ModePerm)
+
+		if err != nil {
+			return contentLen, err
+		}
+
+		err = os.Symlink(path.Join(basePath, paths[i+1]), path.Join(basePath, paths[i]))
+
+		if err != nil {
+			return contentLen, err
+		}
+	}
+
 
 	return contentLen, err
 }

--- a/cmd/lhsm-plugin-az-core/restore.go
+++ b/cmd/lhsm-plugin-az-core/restore.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strings"
 )
 
 type RestoreOptions struct {
@@ -74,7 +75,8 @@ func Restore(o RestoreOptions) (int64, error){
 
 	basePath := path.Dir(o.DestinationPath)
 
-	file, _ := os.Create(path.Join(basePath, paths[len(paths)-1]))
+	// We download to the destination name.
+	file, _ := os.Create(o.DestinationPath)
 	defer file.Close()
 	err = azblob.DownloadBlobToFile(
 		ctx, blobURL, 0, 0, file,
@@ -83,7 +85,8 @@ func Restore(o RestoreOptions) (int64, error){
 			Parallelism: o.Parallelism,
 		})
 
-	//paths = paths[:len(paths)-1]
+	// We symlink to the destination name.
+	paths[len(paths)-1] = strings.TrimPrefix(o.DestinationPath, basePath)
 
 	for i := len(paths) - 2; i >= 0; i-- {
 		err = os.MkdirAll(path.Join(basePath, path.Dir(paths[i])), os.ModeDir | os.ModePerm)

--- a/cmd/lhsm-plugin-az-core/zt_archive_test.go
+++ b/cmd/lhsm-plugin-az-core/zt_archive_test.go
@@ -3,9 +3,126 @@ package lhsm_plugin_az_core
 import (
 	"github.com/Azure/azure-storage-blob-go/azblob"
 	chk "gopkg.in/check.v1"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 )
+
+func performUploadAndDownloadSymlinkTest(c *chk.C, symlinkCount, fileSize, blockSize, parallelism int) {
+	fileName := generateName("", 0)
+	dir, err := ioutil.TempDir("", "upload*")
+	c.Assert(err, chk.IsNil)
+	// make the tmp directory and the subdirectory.
+	os.MkdirAll(filepath.Join(dir, "subdir"), os.ModeDir | os.ModePerm)
+	defer os.RemoveAll(dir)
+	filePath := filepath.Join(dir, fileName)
+
+	// create the file
+	f, err := os.Create(filePath)
+
+	c.Assert(err, chk.IsNil)
+	_, err = f.Write([]byte("Hello world!"))
+	c.Assert(err, chk.IsNil)
+
+	// close the file
+	c.Assert(f.Close(), chk.IsNil)
+
+	lastLink := filePath
+	linkName := ""
+	for i := symlinkCount; i > 0; i-- {
+		linkName = generateName("link", 0)
+		var newLink string
+
+		if i % 2 == 0 {
+			newLink = filepath.Join(dir, "subdir", linkName)
+		} else {
+			newLink = filepath.Join(dir, linkName)
+		}
+
+		c.Assert(os.Symlink(lastLink, newLink), chk.IsNil)
+
+		lastLink = newLink
+	}
+	c.Assert(lastLink, chk.Not(chk.Equals), filePath)
+	c.Assert(linkName, chk.Not(chk.Equals), "")
+
+	// Set up the test container
+	bsu := getBSU()
+	containerURL, containerName := createNewContainer(c, bsu)
+	defer deleteContainer(c, containerURL)
+
+	// Upload the file, targeting the symlink (intended functionality)
+	account, key := getAccountAndKey()
+	credential, err := azblob.NewSharedKeyCredential(account, key)
+	c.Assert(err, chk.IsNil)
+	count, err := Archive(ArchiveOptions{
+		AccountName: account,
+		ContainerName: containerName,
+		BlobName: linkName,
+		SourcePath: lastLink,
+		Credential: credential,
+		Parallelism: uint16(parallelism),
+		BlockSize: int64(blockSize),
+	})
+	c.Assert(err, chk.IsNil)
+	c.Assert(count, chk.Equals, int64(len("Hello world!")))
+
+	// Set up the downloads.
+	dlDir, err := ioutil.TempDir("", "download*")
+	c.Assert(err, chk.IsNil)
+	os.MkdirAll(dlDir, os.ModeDir)
+	defer os.RemoveAll(dlDir)
+	destFilePath := filepath.Join(dlDir, linkName)
+
+	// invoke restore
+	count, err = Restore(RestoreOptions{
+		AccountName:     account,
+		ContainerName:   containerName,
+		BlobName:        strings.TrimPrefix(lastLink, dir + "/"),
+		DestinationPath: destFilePath,
+		Credential:      credential,
+		Parallelism:     uint16(parallelism),
+		BlockSize:       int64(blockSize),
+	})
+
+	// Assert download was successful
+	c.Assert(err, chk.Equals, nil)
+	c.Assert(count, chk.Equals, int64(len("Hello world!")))
+
+	// Assert the folder was the same, and that the file is the same.
+	parameterizeWalkFunc := func(fileMap map[string]bool, rootPath string) filepath.WalkFunc {
+		return func(path string, info os.FileInfo, err error) error {
+			// skip the root
+			if path == rootPath {
+				return err
+			}
+
+			fileMap[strings.TrimPrefix(path, rootPath)] = true
+
+			return err
+		}
+	}
+
+	dlMap := make(map[string]bool)
+	filepath.Walk(dlDir, parameterizeWalkFunc(dlMap, dlDir))
+	ulMap := make(map[string]bool)
+	filepath.Walk(dir, parameterizeWalkFunc(ulMap, dir))
+
+	for k,_ := range dlMap {
+		if _, ok := ulMap[k]; !ok {
+			// If you fail here, one map lacks something.
+			c.Fail()
+		}
+	}
+
+	for k,_ := range ulMap {
+		if _, ok := dlMap[k]; !ok {
+			// If you fail here, one map lacks something.
+			c.Fail()
+		}
+	}
+}
 
 // test upload/download with the source data uploaded to the service from a file
 // this is a round-trip test where both upload and download are exercised together
@@ -78,4 +195,12 @@ func (s *cmdIntegrationSuite) TestUploadAndDownloadFileSingleIO(c *chk.C) {
 	blockSize := 2048
 	parallelism := 3
 	performUploadAndDownloadFileTest(c, fileSize, blockSize, parallelism)
+}
+
+func (s *cmdIntegrationSuite) TestUploadAndDownloadSymlinkFile(c *chk.C) {
+	fileSize := 1024
+	blockSize := 2048
+	parallelism := 3
+	// Test with a large-ish amount of symlinks jumping between sub and same directories.
+	performUploadAndDownloadSymlinkTest(c, 8, fileSize, blockSize, parallelism)
 }


### PR DESCRIPTION
Restore should never encounter a symlink, BUT, defensively (and for the sake of testing upload), it's been programmed in.
Archive probably will encounter symlinks.