### PR TITLE
Remove Personal Identifiable Information(PII) from copytool logging

### DIFF
--- a/cmd/lhsm-plugin-az-core/archive.go
+++ b/cmd/lhsm-plugin-az-core/archive.go
@@ -86,7 +86,11 @@ func upload(ctx context.Context, o ArchiveOptions, blobPath string) (_ int64, er
 
 //Archive copies local file to HNS
 func Archive(ctx context.Context, o ArchiveOptions) (size int64, err error) {
-	util.Log(pipeline.LogInfo, fmt.Sprintf("Archiving %s", o.BlobName))
+	if util.ShouldLog(pipeline.LogDebug) {
+		util.Log(pipeline.LogDebug, fmt.Sprintf("Archiving %s", o.BlobName))
+	} else {
+		util.Log(pipeline.LogInfo, fmt.Sprintf("Archiving %s", o.SourcePath))
+	}
 	wg := sync.WaitGroup{}
 
 	parents := strings.Split(o.BlobName, string(os.PathSeparator))

--- a/cmd/lhsm-plugin-az/main.go
+++ b/cmd/lhsm-plugin-az/main.go
@@ -382,6 +382,8 @@ func getMergedConfig(plugin *dmplugin.Plugin) (*azConfig, error) {
 }
 
 func main() {
+	var minimumLevelToLog pipeline.LogLevel
+
 	plugin, err := dmplugin.New(path.Base(os.Args[0]), func(path string) (fsroot.Client, error) {
 		return fsroot.New(path)
 	})
@@ -408,7 +410,24 @@ func main() {
 		alert.Abort(errors.Wrap(err, "registering HSM event FIFO (plugin)"))
 	}
 	defer llapi.UnregisterErrorCB(cfg.EventFIFOPath)
-	util.InitJobLogger(pipeline.LogDebug)
+
+	switch cfg.LogLevel {
+		case "none":
+			minimumLevelToLog = pipeline.LogNone
+		case "fatal":
+			minimumLevelToLog = pipeline.LogFatal
+		case "panic":
+			minimumLevelToLog = pipeline.LogPanic
+		case "error":
+			minimumLevelToLog = pipeline.LogError
+		case "warning":
+			minimumLevelToLog = pipeline.LogWarning
+		case "info":
+			minimumLevelToLog = pipeline.LogInfo
+		default:
+			minimumLevelToLog = pipeline.LogDebug
+	}
+	util.InitJobLogger(minimumLevelToLog)
 
 	for _, ac := range cfg.Archives {
 		ac.mergeGlobals(cfg)


### PR DESCRIPTION
This is a non-disruptive stop gap change while we wait for a more long term solution for copytool logging. We'll still get PII if the STE encounters and log errors
- Adds change to enable the copytool plugin to use the log level set in the config file. So both the copytool plugin and the STE will use the same log level.
- Adds a change so the copytool plugin can honor the minimum job log level. I.e. log a message according to severity
- We still need to keep "error" log level in the config file for now so that STE is not very verbose. However, "error" log level would make the copytool plugin almost "mute". So conditionally log items for the copytool plugin. That way, we can get all the details if we are running in "debug" mode but get the necessary logging without PII if the log level is set to "error"