### PR TITLE
Fix blocked Cancel requests

### DIFF
--- a/build_plugin.sh
+++ b/build_plugin.sh
@@ -1,3 +1,3 @@
 export CGO_CFLAGS='-I/usr/src/lustre-2.12.5/lustre/include -I/usr/src/lustre-2.12.5/lustre/include/uapi'
 export GOPATH=/go
-go build -v -i -ldflags "-X 'main.version=0.6.0_56_g286df59_dirty'" -o dist/lhsm-plugin-az ./cmd/lhsm-plugin-az
+go build -v -i -ldflags "-X 'main.version=0.6.0_56_g286df59_dirty'" -o dist/lhsm-plugin-az ./cmd/lhsm-plugin-az && go build -v -i -ldflags "-X 'main.version=0.6.0_56_g286df59_dirty'" -o dist/lhsmd ./cmd/lhsmd

--- a/cmd/lhsm-plugin-az-core/remove.go
+++ b/cmd/lhsm-plugin-az-core/remove.go
@@ -21,8 +21,8 @@ type RemoveOptions struct {
 	OpStartTime   time.Time
 }
 
-func Remove(o RemoveOptions) error {
-	ctx, _ := context.WithTimeout(context.Background(), time.Minute * 3)
+func Remove(ctx context.Context, o RemoveOptions) error {
+	ctx, _ = context.WithTimeout(ctx, time.Minute * 3)
 	p := azblob.NewPipeline(o.Credential, azblob.PipelineOptions{})
 	blobPath := path.Join(o.ExportPrefix, o.BlobName)
 	blobURL := azblob.NewContainerURL(*o.ContainerURL, p).NewBlockBlobURL(blobPath)

--- a/cmd/lhsm-plugin-az/main.go
+++ b/cmd/lhsm-plugin-az/main.go
@@ -59,6 +59,7 @@ type (
 
 	azConfig struct {
 		NumThreads            int        `hcl:"num_threads"`
+		ActionQueueSize       int        `hcl:"action_queue_size"`
 		AzStorageAccountURL   string     `hcl:"az_storage_account_url"`
 		AzStorageKVURL        string     `hcl:"az_kv_url"`
 		AzStorageKVSecretName string     `hcl:"az_kv_secret_name"`
@@ -213,6 +214,11 @@ func (c *azConfig) Merge(other *azConfig) *azConfig {
 	result.NumThreads = c.NumThreads
 	if other.NumThreads > 0 {
 		result.NumThreads = other.NumThreads
+	}
+
+	result.ActionQueueSize = c.ActionQueueSize
+	if other.ActionQueueSize > 0 {
+		result.ActionQueueSize = other.ActionQueueSize
 	}
 
 	result.Region = c.Region
@@ -459,6 +465,7 @@ func main() {
 			Mover:      AzMover(ac, getCredential(ac), uint32(ac.ID)),
 			NumThreads: cfg.NumThreads,
 			ArchiveID:  uint32(ac.ID),
+			ActionQueueSize: cfg.ActionQueueSize,
 		})
 	}
 

--- a/cmd/util/misc.go
+++ b/cmd/util/misc.go
@@ -58,6 +58,8 @@ func (e ErrorEx) Error() string {
 	return e.msg
 }
 
+var CopytoolBusy = ErrorEx{code: int32(syscall.EBUSY), msg: "Too many requests on copytool" }
+
 func ShouldRetry(err error) bool {
 	if stgErr, ok := err.(azblob.StorageError); ok {
 		if stgErr.Response().StatusCode == http.StatusForbidden {

--- a/dmplugin/dmclient.go
+++ b/dmplugin/dmclient.go
@@ -24,7 +24,7 @@ import (
 
 type (
 	// ActionHandler is function that implements one of the commands
-	ActionHandler func(Action) error
+	ActionHandler func(context.Context, Action) error
 
 	actionFunc func()
 
@@ -103,23 +103,19 @@ type (
 	// Archiver defines an interface for data movers capable of
 	// fulfilling Archive requests
 	Archiver interface {
-		Archive(Action) error
+		Archive(context.Context, Action) error
 	}
 
 	// Restorer defines an interface for data movers capable of
 	// fulfilling Restore requests
 	Restorer interface {
-		Restore(Action) error
+		Restore(context.Context, Action) error
 	}
 
 	// Remover defines an interface for data movers capable of
 	// fulfilling Remove requests
 	Remover interface {
-		Remove(Action) error
-	}
-
-	Canceler interface {
-		Cancel(Action) error
+		Remove(context.Context, Action) error
 	}
 )
 
@@ -279,9 +275,6 @@ func NewMover(plugin *Plugin, cli pb.DataMoverClient, config *Config) *DataMover
 	if remover, ok := config.Mover.(Remover); ok {
 		actions[pb.Command_REMOVE] = remover.Remove
 	}
-	if canceler, ok := config.Mover.(Canceler); ok {
-		actions[pb.Command_CANCEL] = canceler.Cancel
-	}
 
 	return &DataMoverClient{
 		plugin:    plugin,
@@ -341,6 +334,8 @@ func (dm *DataMoverClient) registerEndpoint(ctx context.Context) (*pb.Handle, er
 
 func (dm *DataMoverClient) processActions(ctx context.Context) chan actionFunc {
 	actions := make(chan actionFunc)
+	var cancelMap sync.Map
+
 	maxTryCount := 3
 	if r := os.Getenv("COPYTOOL_RETRY_COUNT"); r != "" {
 		if v, err := strconv.Atoi(r); err == nil {
@@ -349,7 +344,7 @@ func (dm *DataMoverClient) processActions(ctx context.Context) chan actionFunc {
 	}
 
 	var process func(context.Context, *pb.ActionItem)
-	process = func (_ context.Context, item *pb.ActionItem) {
+	process = func (actionCtx context.Context, item *pb.ActionItem) {
 		action := &dmAction{
 			status: dm.status,
 			item:   item,
@@ -357,14 +352,19 @@ func (dm *DataMoverClient) processActions(ctx context.Context) chan actionFunc {
 
 		actionFn, err := dm.getActionHandler(item.Op)
 		if err == nil {
-			err = actionFn(action)
+			err = actionFn(actionCtx, action)
 		}
 		// debug.Printf("completed (action: %v) %v ", action, ret)
 		if util.ShouldRetry(err) && item.TryCount < int64(maxTryCount) {
 			item.TryCount += 1
-			go func() { actions <- func() { process(context.TODO(), item) } }()
+			// Refresh the context and update cancelMap
+			actionCtx, cancel := context.WithCancel(ctx)
+			cancelMap.Store(action.PrimaryPath(), cancel)
+
+			go func() { actions <- func() { process(actionCtx, item) } }()
 		} else {
 			action.Finish(err)
+			cancelMap.Delete(action.PrimaryPath()) // Delete from map
 		}
 		
 		if err != nil {
@@ -397,7 +397,21 @@ func (dm *DataMoverClient) processActions(ctx context.Context) chan actionFunc {
 			// debug.Printf("Got message id:%d op: %v %v", action.Id, action.Op, action.PrimaryPath)
 
 			action.TryCount = 0 //first try
-			actions <- func() { process(context.TODO(), action) }
+
+			if (action.Op == pb.Command_CANCEL) {
+				// lookup in the map and cancel the context
+				cancel, ok := cancelMap.Load(action.PrimaryPath)
+				if !ok {
+					alert.Warnf("Received Cancel for a non-existent action: %s", action.PrimaryPath)
+					continue
+				}
+				alert.Writer().Log(fmt.Sprintf("id:%d Cancel %s", action.Id, action.PrimaryPath))
+				cancel.(context.CancelFunc)()
+			} else {
+				actionCtx, cancel := context.WithCancel(ctx)
+				cancelMap.Store(action.PrimaryPath, cancel ) // save this so that we can cancel if required
+				actions <- func() { process(actionCtx, action) }
+			}
 		}
 
 	}()

--- a/dmplugin/dmclient.go
+++ b/dmplugin/dmclient.go
@@ -356,6 +356,7 @@ func (dm *DataMoverClient) processActions(parentCtx context.Context) chan action
 		go func() {
 			select {
 			case <-ctx.Done():
+				cancelMap.Delete(action.PrimaryPath())
 			case actions <- func() { processAction(childCtx, action) }:
 			}
 		}()
@@ -389,6 +390,7 @@ func (dm *DataMoverClient) processActions(parentCtx context.Context) chan action
 			msg := fmt.Sprintf("Received cancel for a non-existent action: %s", action.item.PrimaryPath)
 			alert.Warnf(msg)
 			action.Finish(errors.New(msg))
+			return
 		}
 
 		alert.Writer().Log(fmt.Sprintf("id:%d Cancel %s", action.item.Id, action.item.PrimaryPath))


### PR DESCRIPTION
1. Fixes issue in which the Copytool was not honoring queued archive cancel actions from the coordinator.
2. Prioritizes Cancel actions.
3. Fixes the issue in which the Copytool could not Cancel actions after re-starting (a previously cancelled) archive.