### PR TITLE
Support specification of the blob target for archives, removes, and restores by data payload

### DIFF
--- a/cmd/lhsm-plugin-az-core/archive.go
+++ b/cmd/lhsm-plugin-az-core/archive.go
@@ -23,6 +23,7 @@ type ArchiveOptions struct {
 	ContainerURL *container.Client
 	ResourceSAS  string
 	MountRoot    string
+	FID          string
 	BlobName     string
 	SourcePath   string
 	BlockSize    int64
@@ -78,9 +79,9 @@ func (a *ArchiveOptions) getUploadOptions(filepath string) (*blockblob.UploadFil
 
 // Archive copies local file to HNS
 func Archive(ctx context.Context, copier copier.Copier, o ArchiveOptions) (int64, error) {
-	logPath := o.SourcePath //hide paths till debug mode
+	logPath := o.FID //hide paths till debug mode
 	if util.ShouldLog(pipeline.LogDebug) {
-		logPath = o.BlobName
+		logPath = o.SourcePath
 	}
 
 	util.Log(pipeline.LogInfo, fmt.Sprintf("Archiving %s", logPath))
@@ -109,7 +110,7 @@ func Archive(ctx context.Context, copier copier.Copier, o ArchiveOptions) (int64
 		}(filepath, blobpath)
 	}
 
-	filepath = path.Join(o.MountRoot, o.BlobName)
+	filepath = path.Join(o.MountRoot, o.SourcePath)
 	blobpath = path.Join(o.ExportPrefix, o.BlobName)
 	blob := o.ContainerURL.NewBlockBlobClient(blobpath)
 

--- a/cmd/lhsm-plugin-az-core/zt_archive_test.go
+++ b/cmd/lhsm-plugin-az-core/zt_archive_test.go
@@ -30,7 +30,7 @@ func performUploadAndDownloadFileTest(c *chk.C, fileSize, blockSize, parallelism
 	file, err := os.Open(filePath)
 	c.Assert(err, chk.IsNil)
 	defer file.Close()
-	defer os.Remove(fileName)
+	defer os.Remove(filePath)
 
 	// Set up test container
 	bsu := getBSU()
@@ -46,7 +46,7 @@ func performUploadAndDownloadFileTest(c *chk.C, fileSize, blockSize, parallelism
 	count, err := Archive(context.Background(), copier, ArchiveOptions{
 		ContainerURL: containerURL,
 		BlobName:     fileName,
-		SourcePath:   filePath,
+		SourcePath:   fileName,
 		BlockSize:    int64(blockSize),
 		MountRoot:    os.TempDir(),
 		HTTPClient:   &http.Client{},
@@ -60,7 +60,7 @@ func performUploadAndDownloadFileTest(c *chk.C, fileSize, blockSize, parallelism
 	destFile, err := os.Create(destFilePath)
 	c.Assert(err, chk.Equals, nil)
 	defer destFile.Close()
-	defer os.Remove(destFileName)
+	defer os.Remove(destFilePath)
 
 	blobName := fileName
 	// invoke restore to download the file back
@@ -110,7 +110,7 @@ func (_ *cmdIntegrationSuite) TestPreservePermsRecursive(c *chk.C) {
 	file, err := os.Open(filePath)
 	c.Assert(err, chk.IsNil)
 	defer file.Close()
-	defer os.Remove(fileName)
+	defer os.Remove(filePath)
 
 	// Set up test container
 	bsu := getBSU()
@@ -124,7 +124,7 @@ func (_ *cmdIntegrationSuite) TestPreservePermsRecursive(c *chk.C) {
 	count, err := Archive(context.Background(), copier, ArchiveOptions{
 		ContainerURL: containerURL,
 		BlobName:     fileName,
-		SourcePath:   filePath,
+		SourcePath:   fileName,
 		BlockSize:    int64(2048), //2M
 		MountRoot:    tempDir,
 		HTTPClient:   &http.Client{},

--- a/dmplugin/dmclient.go
+++ b/dmplugin/dmclient.go
@@ -72,6 +72,8 @@ type (
 		Data() []byte
 		// PrimaryPath returns the action item's primary file path
 		PrimaryPath() string
+		// FileID returns the action item's primary file path
+		FileID() string
 
 		// WritePath returns the action item's write path (e.g. for restores)
 		WritePath() string
@@ -206,6 +208,11 @@ func (a *dmAction) Data() []byte {
 // PrimaryPath returns the action item's primary file path
 func (a *dmAction) PrimaryPath() string {
 	return a.item.PrimaryPath
+}
+
+// FileID returns the action item's FileID
+func (a *dmAction) FileID() string {
+	return a.item.Uuid
 }
 
 // WritePath returns the action item's write path (e.g. for restores)


### PR DESCRIPTION
This change primarily makes functional deletion of files from blob that no longer exist in Lustre, but also supports the archive of files from one location in Lustre to a different location in blob, and restore from a different location in Blob than the target in Lustre.  To support that, the file id is converted to a string to make specification of the blob path more straightforward, and the uuid still present in the rpc payload is re-used to pass this information from the lhsmd to the plugin (this is how it was previously functioning as well).