### PR TITLE
Personal/cramavarapu/sas token copier propagation

### DIFF
--- a/cmd/lhsm-plugin-az-core/restore.go
+++ b/cmd/lhsm-plugin-az-core/restore.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Azure/azure-pipeline-go/pipeline"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	copier "github.com/wastore/lemur/copier/core"
 	"github.com/wastore/lemur/cmd/util"
@@ -23,6 +24,7 @@ type RestoreOptions struct {
 	ExportPrefix    string
 	HTTPClient      *http.Client
 	OpStartTime     time.Time
+	GetNewStorageClients func(string) (*container.Client, *blockblob.Client, error)
 }
 
 var maxRetryPerDownloadBody = 5
@@ -58,7 +60,7 @@ func Restore(ctx context.Context, copier copier.Copier, o RestoreOptions) (int64
 		BlockSize: o.BlockSize,
 		Progress: progressFunc,
 	}
-	size, err := copier.DownloadFile(ctx, b, o.DestinationPath, &options)
+	size, err := copier.DownloadFile(ctx, b, o.BlobName, o.DestinationPath, &options, o.GetNewStorageClients)
 	if err != nil {
 		util.Log(pipeline.LogError, fmt.Sprintf("Restore failed: %v", err))
 		return 0, err

--- a/copier/core/copier.go
+++ b/copier/core/copier.go
@@ -26,13 +26,18 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 )
 
 var ErrCopierClosed = errors.New("copier closed")
 
+// A callback to get a new container and a new block blob client in case the
+// previous client was tied to an expired SAS token
+type NewStorageClientsCb func(string) (*container.Client, *blockblob.Client, error)
+
 type Copier interface {
-	DownloadFile(ctx context.Context, bb *blockblob.Client, filepath string, o *blob.DownloadFileOptions) (int64, error)
-	UploadFile(ctx context.Context, b *blockblob.Client, filepath string, o *blockblob.UploadFileOptions) error
+	DownloadFile(ctx context.Context, bb *blockblob.Client, blobpath string, filepath string, o *blob.DownloadFileOptions, getNewStorageClientsCb NewStorageClientsCb) (int64, error)
+	UploadFile(ctx context.Context, b *blockblob.Client, filepath string, blobpath string, o *blockblob.UploadFileOptions, getNewStorageClientsCb NewStorageClientsCb) error
 	Close()
 }
 

--- a/copier/core/upload.go
+++ b/copier/core/upload.go
@@ -236,8 +236,7 @@ func (c *copier) uploadInternal(ctx context.Context,
 		// buffer is full. Since the buffer is sized to match the block
 		// size or be exactly the remaining number of bytes, io.EOF is
 		// not handled.
-		var n int
-		if n, err = io.ReadFull(file, buff); err != nil {
+		if _, err = io.ReadFull(file, buff); err != nil {
 			setErrorIfNotCancelled(err)
 			break
 		}


### PR DESCRIPTION
Copytool copier library should be able to access refreshed SAS tokens

This commit caches 403 Forbidden errors at the copier layer that can
result from SAS token expiration during a download or upload. When the
copier encounters this error it (or the faulting go routine) call a
call back into the mover to force a refresh of the SAS token and
recreation of both the container client and blockblob client.

As a minor change, debug print messages were added to the copier along error paths in order to simplify investigation.
